### PR TITLE
Feature/api https switch

### DIFF
--- a/src/utilities/apiCalls.js
+++ b/src/utilities/apiCalls.js
@@ -1,15 +1,15 @@
 export const getTopArtists = (country) => {
-  return fetch(`http://ws.audioscrobbler.com/2.0/?method=geo.gettopartists&country=${country}&api_key=18f07debe7c3cfc543178cd9046e1ec4&format=json`)
+  return fetch(`https://ws.audioscrobbler.com/2.0/?method=geo.gettopartists&country=${country}&api_key=18f07debe7c3cfc543178cd9046e1ec4&format=json`)
     .then(response => response.json());
 }
 
 export const getTopTracks = (country) => {
-  return fetch(`http://ws.audioscrobbler.com/2.0/?method=geo.gettoptracks&country=${country}&api_key=18f07debe7c3cfc543178cd9046e1ec4&format=json`)
+  return fetch(`https://ws.audioscrobbler.com/2.0/?method=geo.gettoptracks&country=${country}&api_key=18f07debe7c3cfc543178cd9046e1ec4&format=json`)
     .then(response => response.json());
 }
 
 export const getArtistInfo = (artistName) => {
-  return fetch(`http://ws.audioscrobbler.com/2.0/?method=artist.getinfo&artist=${artistName}&api_key=18f07debe7c3cfc543178cd9046e1ec4&format=json`)
+  return fetch(`https://ws.audioscrobbler.com/2.0/?method=artist.getinfo&artist=${artistName}&api_key=18f07debe7c3cfc543178cd9046e1ec4&format=json`)
     .then(response => response.json());
 }
 

--- a/src/utilities/apiCalls.js
+++ b/src/utilities/apiCalls.js
@@ -13,15 +13,14 @@ export const getArtistInfo = (artistName) => {
     .then(response => response.json());
 }
 
-export const getArtistImagePage = async ( id) => {
+export const getArtistImagePage = async (id) => {
   const response = await fetch(`http://musicbrainz.org/ws/2/artist/${id}?inc=url-rels&fmt=json`)
   const data = await response.json();
 
   return data;
 }
 
-  // async getArtistImageURL() {
-  //   const response = await fetch(`http://commons.wikimedia.org/wiki/File:ArianaGrandeDecember2013.jpg`)
-  //   const data = await response.json();
-  //   console.log(data);
-  // }
+// export const getArtistImageURL = async () => {
+//   const response = await fetch(`http://commons.wikimedia.org/wiki/File:ArianaGrandeDecember2013.jpg`)
+//   const data = await response.json();
+// }


### PR DESCRIPTION
### Is this a fix or a feature?
- Fix, hopefully.

### What is the change or fix?
- Switched API URLs from HTTP to HTTPs in an effort to resolve errors on deployed Heroku site.  API data failed to fetch and display on initial display, logging the following error:
_"Mixed Content: The page at '<URL>' was loaded over HTTPS, but requested an insecure resource '<URL>'. This request has been blocked; the content must be served over HTTPS."_

### How should this be tested?
- Rebuild Heroku deploy, display in browser and inspect console.
